### PR TITLE
Prettier + ESLint + VSCode settings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+    "prettier/@typescript-eslint"
+  ],
+  "rules": {
+    "no-var": "error",
+    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/ban-ts-ignore": "off",
+    "@typescript-eslint/no-unused-vars": "warn"
+  }
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.formatOnSave": true,
+  "eslint.enable": true,
+  "eslint.alwaysShowStatus": true,
+  "eslint.autoFixOnSave": true,
+  "eslint.packageManager": "yarn",
+  "eslint.validate": [
+    "javascript",
+    "typescript"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "webpack-dev-server --config ./webpack.development.js",
     "build": "webpack --config ./webpack.production.js",
-    "test": "karma start --single-run --browsers ChromeHeadless karma.conf.js"
+    "test": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
+    "fix-ts": "eslint --fix 'src/**/*.ts'"
   },
   "repository": {
     "type": "git",
@@ -29,14 +30,20 @@
   "devDependencies": {
     "@nimiq/core-types": "^1.4.2",
     "@types/jasmine": "^3.4.2",
+    "@typescript-eslint/eslint-plugin": "^2.5.0",
+    "@typescript-eslint/parser": "^2.5.0",
     "css-loader": "^3.2.0",
     "dotenv-webpack": "^1.7.0",
+    "eslint": "^6.5.1",
+    "eslint-config-prettier": "^6.4.0",
+    "eslint-plugin-prettier": "^3.1.1",
     "html-webpack-plugin": "^3.2.0",
     "jasmine-core": "^3.5.0",
     "karma": "^4.3.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-jasmine": "^2.0.1",
     "karma-webpack": "^4.0.2",
+    "prettier": "^1.18.2",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.2.0",
     "typescript": "^3.6.3",

--- a/src/admin/admin.js
+++ b/src/admin/admin.js
@@ -1,33 +1,32 @@
-import Shop from '../js/shop.js';
+import Shop from '../js/shop.js'
 
-const { privateKey, publicKey } = localStorage;
-const shop = new Shop();
-const $ = document.getElementById.bind(document);
+const { privateKey, publicKey } = localStorage
+const shop = new Shop()
+const $ = document.getElementById.bind(document)
 
 function initialize() {
-    console.log(privateKey);
-    if (!privateKey) {
-        console.log('Setup required.');
-        return location.href = 'setup.html';
-    }
+  console.log(privateKey)
+  if (!privateKey) {
+    console.log('Setup required.')
+    return (location.href = 'setup.html')
+  }
 
-    loadOpenOrders();
+  loadOpenOrders()
 }
 
 async function loadOpenOrders() {
-    const orders = await shop.data.list(privateKey);
-    const list = $('open_orders');
-    list.innerHTML = '';
-    if (list.length > 0) {
-        orders.forEach(order => {
-            const li = document.createElement('li');
-            li.textContent = order;
-            list.appendChild(li);
-        });
-    }
-    else {
-        list.textContent = 'none';
-    }
+  const orders = await shop.data.list(privateKey)
+  const list = $('open_orders')
+  list.innerHTML = ''
+  if (list.length > 0) {
+    orders.forEach(order => {
+      const li = document.createElement('li')
+      li.textContent = order
+      list.appendChild(li)
+    })
+  } else {
+    list.textContent = 'none'
+  }
 }
 
-window.addEventListener('load', initialize);
+window.addEventListener('load', initialize)

--- a/src/components/checkout-button.ts
+++ b/src/components/checkout-button.ts
@@ -1,121 +1,124 @@
-import { LitElement, html, property, customElement} from 'lit-element';
+import {
+  LitElement,
+  html,
+  property,
+  customElement,
+  TemplateResult,
+  CSSResult,
+} from 'lit-element'
 import buttonStyles from '../styles/buttons'
 import typographyStyles from '../styles/typography'
 import themeStyles from '../styles/theme'
 
-export const TAG_NAME = 'nimiq-shop-checkout-button';
+export const TAG_NAME = 'nimiq-shop-checkout-button'
 
 @customElement(TAG_NAME)
 export class CheckoutButton extends LitElement {
-
-  static get styles() {
-    return [
-      themeStyles,
-      buttonStyles,
-      typographyStyles
-    ]
+  static get styles(): CSSResult[] {
+    return [themeStyles, buttonStyles, typographyStyles]
   }
 
   /**
    * Optional label of the button - if not provided, product name will be used.
    */
-  @property({type: String}) 
-  label = '';
-  
-  protected get hasLabel(): Boolean {
+  @property({ type: String })
+  label = ''
+
+  protected get hasLabel(): boolean {
     return this.label.trim().length > 0
   }
-  
+
   /**
    * Name of the product to buy
    */
-  @property({type: String}) 
-  name = '';
-  
+  @property({ type: String })
+  name = ''
+
   /**
    * Price of the product to buy in NIM, minimum `0.00001`
    */
-  @property({type: Number}) 
-  price = 0;
+  @property({ type: Number })
+  price = 0
 
   /**
    * Flag to inverse button style
    */
-  @property({type: Boolean}) 
-  inverse = false;
+  @property({ type: Boolean })
+  inverse = false
 
-  protected get buttonInverseClass(): String {
-    return (this.inverse) ? 'inverse' : ''
+  protected get buttonInverseClass(): string {
+    return this.inverse ? 'inverse' : ''
   }
 
   /**
    * Flag to style a small button size
    */
-  @property({type: Boolean}) 
-  small = false;
+  @property({ type: Boolean })
+  small = false
 
   /**
    * Flag to style a pill button
    */
-  @property({type: Boolean}) 
-  pill = false;
-  
-  protected get buttonClass(): String {
-    return (this.small) 
-      ? 'nq-button-s' : (this.pill) 
-        ? 'nq-button-pill' 
-        : 'nq-button'
+  @property({ type: Boolean })
+  pill = false
+
+  protected get buttonClass(): string {
+    return this.small
+      ? 'nq-button-s'
+      : this.pill
+      ? 'nq-button-pill'
+      : 'nq-button'
   }
-  
+
   /**
    * Flag to disable the button
    */
-  @property({type: Boolean}) 
-  disable = false;
+  @property({ type: Boolean })
+  disable = false
 
   /**
    * Button color class
    */
-  @property({type: String}) 
-  buttonColor = '';
-  
-  protected get buttonColorClass(): String {
-    return [
-      'light-blue',
-      'green',
-      'orange',
-      'red',
-      'gold'
-      ].includes(this.buttonColor) ? this.buttonColor : '';
+  @property({ type: String })
+  buttonColor = ''
+
+  protected get buttonColorClass(): string {
+    return ['light-blue', 'green', 'orange', 'red', 'gold'].includes(
+      this.buttonColor,
+    )
+      ? this.buttonColor
+      : ''
   }
 
-  protected get classNames(): String {
-    let classes = [
+  protected get classNames(): string {
+    const classes = [
       this.buttonClass,
       this.buttonColorClass,
       this.buttonInverseClass,
-    ];
+    ]
     return classes.join(' ')
   }
 
-  clickHandler(ev: Event):void {
+  clickHandler(): void {
     const event = new CustomEvent('checkout', {
       detail: {
-        product: this.name, 
-        price: this.price
-      }
-    });
-    this.dispatchEvent(event);
+        product: this.name,
+        price: this.price,
+      },
+    })
+    this.dispatchEvent(event)
   }
 
-  render() {
+  render(): TemplateResult {
     return html`
-      <button 
+      <button
         class="${this.classNames}"
         ?disabled="${this.disable}"
         class="nq-button"
-        @click="${this.clickHandler}">
-          ${this.hasLabel ? this.label : this.name}
-      </button>`;
+        @click="${this.clickHandler}"
+      >
+        ${this.hasLabel ? this.label : this.name}
+      </button>
+    `
   }
 }

--- a/src/components/shop.ts
+++ b/src/components/shop.ts
@@ -1,7 +1,13 @@
-import { LitElement, html, property, customElement } from 'lit-element';
-import {TAG_NAME as BUTTON_TAG_NAME} from './checkout-button';
+import {
+  LitElement,
+  html,
+  property,
+  customElement,
+  TemplateResult,
+} from 'lit-element'
+import { TAG_NAME as BUTTON_TAG_NAME } from './checkout-button'
 
-const TAG_NAME = 'nimiq-shop';
+const TAG_NAME = 'nimiq-shop'
 
 /**
  * <nimiq-shop> web component
@@ -13,32 +19,32 @@ const TAG_NAME = 'nimiq-shop';
  */
 @customElement(TAG_NAME)
 export class NimiqShop extends LitElement {
-  @property({type: String}) 
-  address = '';
+  @property({ type: String })
+  address = ''
 
-  connectedCallback() {
+  connectedCallback(): void {
     super.connectedCallback()
-    for (let button of document.getElementsByTagName(BUTTON_TAG_NAME) ) {
-      button.addEventListener('checkout', this.checkout);
+    for (const button of document.getElementsByTagName(BUTTON_TAG_NAME)) {
+      button.addEventListener('checkout', this.checkout)
     }
   }
 
-  disconnectedCallback() {
+  disconnectedCallback(): void {
     super.disconnectedCallback()
-    for (let button of this.getElementsByTagName(BUTTON_TAG_NAME)) {
-      button.removeEventListener('checkout', this.checkout);
+    for (const button of this.getElementsByTagName(BUTTON_TAG_NAME)) {
+      button.removeEventListener('checkout', this.checkout)
     }
   }
 
   protected checkout(ev: CustomEvent): void {
-    console.log("checkout", ev)
+    console.log('checkout', ev)
   }
-  
-  render() {
+
+  render(): TemplateResult {
     // Render all nested children using <slot/>
     // https://lit-element.polymer-project.org/guide/templates#render-light-dom-children-with-the-slot-element
     return html`
       <slot></slot>
-    `;
+    `
   }
 }

--- a/src/example.spec.ts
+++ b/src/example.spec.ts
@@ -1,8 +1,6 @@
-
 // TODO(sectore) Delete example test ...
 describe('example', () => {
-
-    it('hello world', async () => {
-        expect('hello world').toBe('hello world');
-    });
-});
+  it('hello world', async () => {
+    expect('hello world').toBe('hello world')
+  })
+})

--- a/src/polyfills/custom-event.ts
+++ b/src/polyfills/custom-event.ts
@@ -1,15 +1,15 @@
-https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
-(function () {
+//developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+;(function(): boolean {
+  if (typeof window.CustomEvent === 'function') return false
 
-  if ( typeof window.CustomEvent === "function" ) return false;
-
-  function CustomEvent ( event, params ) {
-    params = params || { bubbles: false, cancelable: false, detail: null };
-    var evt = document.createEvent( 'CustomEvent' );
-    evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
-    return evt;
-   }
+  /*eslint @typescript-eslint/no-explicit-any: "off"*/
+  function CustomEvent(event, params): CustomEvent<any> {
+    params = params || { bubbles: false, cancelable: false, detail: null }
+    const evt = document.createEvent('CustomEvent')
+    evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail)
+    return evt
+  }
 
   // @ts-ignore
-  window.CustomEvent = CustomEvent;
-})();
+  window.CustomEvent = CustomEvent
+})()

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,5 +1,5 @@
-import {encryptObject, decryptObject} from './utils/crypto';
-import {Order} from './types/shop'
+import { encryptObject, decryptObject } from './utils/crypto'
+import { Order } from './types/shop'
 
 export interface ShopStorage {
   store(order: Order): Promise<string>
@@ -8,65 +8,63 @@ export interface ShopStorage {
 }
 
 export class DummyShopStorage implements ShopStorage {
-
-  protected repository: string;
-  protected namespace: string;
+  protected repository: string
+  protected namespace: string
 
   constructor(repository: string) {
-    this.repository = repository;
-    this.namespace = `dummy-${this.repository}`;
+    this.repository = repository
+    this.namespace = `dummy-${this.repository}`
   }
 
   // TODO(sectore): Do we still need this static `create` function?
   static async create(repository: string): Promise<DummyShopStorage> {
-    const dummy = new DummyShopStorage(repository);
-    return new Promise(resolve => resolve(dummy));
+    const dummy = new DummyShopStorage(repository)
+    return new Promise(resolve => resolve(dummy))
   }
 
-  protected _id(id: string): string { 
-    return `${this.namespace}-${id}`; 
+  protected _id(id: string): string {
+    return `${this.namespace}-${id}`
   }
 
   async store(order: Order): Promise<string> {
-    const id = Math.floor(Math.random()*10e10).toString(16);
-    const encrypted = await encryptObject(order);
-    localStorage.setItem(this._id(id), encrypted);
-    return new Promise(resolve => resolve(id));
+    const id = Math.floor(Math.random() * 10e10).toString(16)
+    const encrypted = await encryptObject(order)
+    localStorage.setItem(this._id(id), encrypted)
+    return new Promise(resolve => resolve(id))
   }
 
   async load(id: string, privateKey: string): Promise<Order> {
     const order = localStorage.getItem(this._id(id))
     if (order != null) {
-      return await decryptObject(order);
+      return await decryptObject(order)
     } else {
       return new Promise((_, reject) => {
         reject(`Order with id ${id} not found in storage`)
-      });
+      })
     }
   }
 
   async list(privateKey: string): Promise<Order[]> {
-    let encrypted: string[] = [];
+    const encrypted: string[] = []
     for (let x = 0; x < localStorage.length; x++) {
-        const key = localStorage.key(x);
-        if (key.startsWith(this.namespace)) {
-          encrypted.push(localStorage.getItem(key));
-        }
+      const key = localStorage.key(x)
+      if (key.startsWith(this.namespace)) {
+        encrypted.push(localStorage.getItem(key))
+      }
     }
     // TODO(sectore) Fix types
     // return encrypted.map(
     //   async o => await decryptObject<Order>(o)
     // );
-    return [];
+    return []
   }
 }
 
 export class IpfsShopStorage implements ShopStorage {
+  protected repository: string
 
-  protected repository: string;
-  
   constructor(repository: string) {
-    this.repository = repository;
+    this.repository = repository
   }
 
   // static async create(repo) {
@@ -77,19 +75,19 @@ export class IpfsShopStorage implements ShopStorage {
   // }
 
   store(order: Order): Promise<string> {
-    console.warn('not implemented!');
+    console.warn('not implemented!')
     // TODO(sectore): Implementation
     return null
   }
 
   load(id: string, privateKey: string): Promise<Order> {
-    console.warn('not implemented!');
+    console.warn('not implemented!')
     // TODO(sectore): Implementation
     return null
   }
 
   list(privateKey: string): Promise<Order[]> {
-    console.warn('not implemented!');
+    console.warn('not implemented!')
     // TODO(sectore): Implementation
     return null
   }

--- a/src/styles/buttons.ts
+++ b/src/styles/buttons.ts
@@ -1,408 +1,411 @@
-import { css } from 'lit-element';
+import { css } from 'lit-element'
 
 // https://github.com/nimiq/nimiq-style/blob/master/src/buttons.css
 export default css`
   .nq-button::-moz-focus-inner,
   .nq-button-s::-moz-focus-inner {
-      border: 0;
+    border: 0;
   }
 
   .nq-button {
-      position: relative;
-      height: 7.5rem;
-      line-height: 2.5rem;
-      background-image: var(--nimiq-blue-bg);
-      color: white;
-      font-size: 2rem;
-      font-weight: bold;
-      text-transform: uppercase;
-      letter-spacing: 0.094em;
-      border: none;
-      padding: 0 4rem;
-      border-radius: 500px;
-      min-width: 25rem;
-      margin: 2rem auto;
-      box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.15);
-      cursor: pointer;
-      transition: transform 450ms var(--nimiq-ease), box-shadow 450ms var(--nimiq-ease);
-      will-change: box-shadow;
-      text-decoration: none;
-      display: block;
-      text-align: center;
-      font-family: inherit;
+    position: relative;
+    height: 7.5rem;
+    line-height: 2.5rem;
+    background-image: var(--nimiq-blue-bg);
+    color: white;
+    font-size: 2rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.094em;
+    border: none;
+    padding: 0 4rem;
+    border-radius: 500px;
+    min-width: 25rem;
+    margin: 2rem auto;
+    box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.15);
+    cursor: pointer;
+    transition: transform 450ms var(--nimiq-ease),
+      box-shadow 450ms var(--nimiq-ease);
+    will-change: box-shadow;
+    text-decoration: none;
+    display: block;
+    text-align: center;
+    font-family: inherit;
   }
 
   a.nq-button {
-      display: flex;
-      justify-content: center;
-      align-items: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 
   .nq-button:not([disabled])::before {
-      content: "";
-      position: absolute;
-      left: 0;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      border-radius: 500px;
-      background-image: var(--nimiq-blue-bg-darkened);
-      opacity: 0;
-      transition: opacity 300ms var(--nimiq-ease);
-      z-index: -1;
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    border-radius: 500px;
+    background-image: var(--nimiq-blue-bg-darkened);
+    opacity: 0;
+    transition: opacity 300ms var(--nimiq-ease);
+    z-index: -1;
   }
 
   .nq-button:hover,
   .nq-button:focus {
-      box-shadow: 0 1rem 2.5rem rgba(0,0,0,0.2);
-      transform: translate3D(0,-2px,0);
+    box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.2);
+    transform: translate3D(0, -2px, 0);
   }
 
   .nq-button:hover::before,
   .nq-button:active::before,
   .nq-button:focus::before {
-      opacity: 1;
+    opacity: 1;
   }
 
   .nq-button:active {
-      outline: none;
-      box-shadow: 0 .2rem .3rem rgba(0,0,0,0.2);
-      transform: translate3D(0,1px,0);
-      transition: transform 200ms cubic-bezier(.41,.34,.26,1.55), box-shadow 200ms cubic-bezier(.41,.34,.26,1.55) !important;
+    outline: none;
+    box-shadow: 0 0.2rem 0.3rem rgba(0, 0, 0, 0.2);
+    transform: translate3D(0, 1px, 0);
+    transition: transform 200ms cubic-bezier(0.41, 0.34, 0.26, 1.55),
+      box-shadow 200ms cubic-bezier(0.41, 0.34, 0.26, 1.55) !important;
   }
 
   .nq-button-s,
   .nq-button-pill {
-      display: inline-block;
-      font-size: 1.75rem;
-      line-height: 3.375rem;
-      height: 3.375rem;
-      text-decoration: none;
-      font-weight: bold;
-      padding: 0 1.5rem;
-      background-color: rgba(31, 35, 72, 0.07); /* Based on Nimiq Blue */
-      color: var(--nimiq-blue);
-      border-radius: 1.6875rem;
-      transition: color 300ms var(--nimiq-ease), background-color 300ms var(--nimiq-ease);
-      will-change: color, background-color;
-      border: none;
-      cursor: pointer;
-      position: relative;
-      font-family: inherit;
+    display: inline-block;
+    font-size: 1.75rem;
+    line-height: 3.375rem;
+    height: 3.375rem;
+    text-decoration: none;
+    font-weight: bold;
+    padding: 0 1.5rem;
+    background-color: rgba(31, 35, 72, 0.07); /* Based on Nimiq Blue */
+    color: var(--nimiq-blue);
+    border-radius: 1.6875rem;
+    transition: color 300ms var(--nimiq-ease),
+      background-color 300ms var(--nimiq-ease);
+    will-change: color, background-color;
+    border: none;
+    cursor: pointer;
+    position: relative;
+    font-family: inherit;
   }
 
   .nq-button-s[disabled] {
-      opacity: 0.4;
-      cursor: not-allowed;
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 
   .nq-button-s::before,
   .nq-button-pill::before {
-      content: '';
-      display: block;
-      position: absolute;
-      left: -1.5rem;
-      top: -1.5rem;
-      right: -1.5rem;
-      bottom: -1.5rem;
+    content: '';
+    display: block;
+    position: absolute;
+    left: -1.5rem;
+    top: -1.5rem;
+    right: -1.5rem;
+    bottom: -1.5rem;
   }
 
   .nq-button-s:hover,
   .nq-button-s:active,
   .nq-button-s:focus {
-      color: var(--nimiq-blue-darkened);
-      background: rgba(31, 35, 72, 0.12); /* Based on Nimiq Blue */
+    color: var(--nimiq-blue-darkened);
+    background: rgba(31, 35, 72, 0.12); /* Based on Nimiq Blue */
   }
 
   .nq-button-s[disabled]:hover {
-      background: rgba(31, 35, 72, 0.07); /* Based on Nimiq Blue */
+    background: rgba(31, 35, 72, 0.07); /* Based on Nimiq Blue */
   }
 
   .nq-button-pill {
-      color: white;
-      background: var(--nimiq-blue);
-      background-image: var(--nimiq-blue-bg);
+    color: white;
+    background: var(--nimiq-blue);
+    background-image: var(--nimiq-blue-bg);
   }
 
   .nq-button-pill:hover,
   .nq-button-pill:active,
   .nq-button-pill:focus {
-      background: var(--nimiq-blue-darkened);
-      background-image: var(--nimiq-blue-bg-darkened);
+    background: var(--nimiq-blue-darkened);
+    background-image: var(--nimiq-blue-bg-darkened);
   }
 
   /* Color variations */
 
   /* light blue */
   .nq-button.light-blue {
-      background: var(--nimiq-light-blue);
-      background-image: var(--nimiq-light-blue-bg);
+    background: var(--nimiq-light-blue);
+    background-image: var(--nimiq-light-blue-bg);
   }
 
   .nq-button.light-blue::before {
-      background-image: var(--nimiq-light-blue-bg-darkened);
+    background-image: var(--nimiq-light-blue-bg-darkened);
   }
 
   .nq-button.light-blue.inverse {
-      color: var(--nimiq-light-blue);
+    color: var(--nimiq-light-blue);
   }
 
   .nq-button.light-blue.inverse:hover,
   .nq-button.light-blue.inverse:active,
   .nq-button.light-blue.inverse:focus {
-      color: var(--nimiq-light-blue-darkened);
+    color: var(--nimiq-light-blue-darkened);
   }
 
   .nq-button-s.light-blue {
-      color: var(--nimiq-light-blue);
-      background: rgba(5, 130, 202, 0.1); /* Based on Nimiq Light Blue */
+    color: var(--nimiq-light-blue);
+    background: rgba(5, 130, 202, 0.1); /* Based on Nimiq Light Blue */
   }
 
   .nq-button-s.light-blue:hover,
   .nq-button-s.light-blue:active,
   .nq-button-s.light-blue:focus {
-      color: var(--nimiq-light-blue-darkened);
-      background: rgba(5, 130, 202, 0.2); /* Based on Nimiq Light Blue */
+    color: var(--nimiq-light-blue-darkened);
+    background: rgba(5, 130, 202, 0.2); /* Based on Nimiq Light Blue */
   }
 
   .nq-button-s.light-blue[disabled]:hover {
-      color: var(--nimiq-light-blue);
-      background: rgba(5, 130, 202, 0.1); /* Based on Nimiq Light Blue */
+    color: var(--nimiq-light-blue);
+    background: rgba(5, 130, 202, 0.1); /* Based on Nimiq Light Blue */
   }
 
   .nq-button-pill.light-blue {
-      background: var(--nimiq-light-blue);
-      background-image: var(--nimiq-light-blue-bg);
+    background: var(--nimiq-light-blue);
+    background-image: var(--nimiq-light-blue-bg);
   }
 
   .nq-button-pill.light-blue:hover,
   .nq-button-pill.light-blue:active,
   .nq-button-pill.light-blue:focus {
-      background: var(--nimiq-light-blue-darkened);
-      background-image: var(--nimiq-light-blue-bg-darkened);
+    background: var(--nimiq-light-blue-darkened);
+    background-image: var(--nimiq-light-blue-bg-darkened);
   }
 
   /* green */
   .nq-button.green {
-      background: var(--nimiq-green);
-      background-image: var(--nimiq-green-bg);
+    background: var(--nimiq-green);
+    background-image: var(--nimiq-green-bg);
   }
 
   .nq-button.green::before {
-      background-image: var(--nimiq-green-bg-darkened);
+    background-image: var(--nimiq-green-bg-darkened);
   }
 
   .nq-button.green.inverse {
-      color: var(--nimiq-green);
+    color: var(--nimiq-green);
   }
 
   .nq-button.green.inverse:hover,
   .nq-button.green.inverse:active,
   .nq-button.green.inverse:focus {
-      color: var(--nimiq-green-darkened);
+    color: var(--nimiq-green-darkened);
   }
 
   .nq-button-s.green {
-      color: var(--nimiq-green);
-      background: rgba(33, 188, 165, 0.1); /* Based on Nimiq Green */
+    color: var(--nimiq-green);
+    background: rgba(33, 188, 165, 0.1); /* Based on Nimiq Green */
   }
 
   .nq-button-s.green:hover,
   .nq-button-s.green:active,
   .nq-button-s.green:focus {
-      color: var(--nimiq-green-darkened);
-      background: rgba(33, 188, 165, 0.2); /* Based on Nimiq Green */
+    color: var(--nimiq-green-darkened);
+    background: rgba(33, 188, 165, 0.2); /* Based on Nimiq Green */
   }
 
   .nq-button-s.green[disabled]:hover {
-      color: var(--nimiq-green);
-      background: rgba(33, 188, 165, 0.1); /* Based on Nimiq Green */
+    color: var(--nimiq-green);
+    background: rgba(33, 188, 165, 0.1); /* Based on Nimiq Green */
   }
 
   .nq-button-pill.green {
-      background: var(--nimiq-green);
-      background-image: var(--nimiq-green-bg);
+    background: var(--nimiq-green);
+    background-image: var(--nimiq-green-bg);
   }
 
   .nq-button-pill.green:hover,
   .nq-button-pill.green:active,
   .nq-button-pill.green:focus {
-      background: var(--nimiq-green-darkened);
-      background-image: var(--nimiq-green-bg-darkened);
+    background: var(--nimiq-green-darkened);
+    background-image: var(--nimiq-green-bg-darkened);
   }
 
   /* orange */
   .nq-button.orange {
-      background: var(--nimiq-orange);
-      background-image: var(--nimiq-orange-bg);
+    background: var(--nimiq-orange);
+    background-image: var(--nimiq-orange-bg);
   }
 
   .nq-button.orange::before {
-      background-image: var(--nimiq-orange-bg-darkened);
+    background-image: var(--nimiq-orange-bg-darkened);
   }
 
   .nq-button.orange.inverse {
-      color: var(--nimiq-orange);
+    color: var(--nimiq-orange);
   }
 
   .nq-button.orange.inverse:hover,
   .nq-button.orange.inverse:active,
   .nq-button.orange.inverse:focus {
-      color: var(--nimiq-orange-darkened);
+    color: var(--nimiq-orange-darkened);
   }
 
   .nq-button-s.orange {
-      color: var(--nimiq-orange);
-      background: rgba(252, 135, 2, 0.1); /* Based on Nimiq Orange */
+    color: var(--nimiq-orange);
+    background: rgba(252, 135, 2, 0.1); /* Based on Nimiq Orange */
   }
 
   .nq-button-s.orange:hover,
   .nq-button-s.orange:active,
   .nq-button-s.orange:focus {
-      color: var(--nimiq-orange-darkened);
-      background: rgba(252, 135, 2, 0.2); /* Based on Nimiq Orange */
+    color: var(--nimiq-orange-darkened);
+    background: rgba(252, 135, 2, 0.2); /* Based on Nimiq Orange */
   }
 
   .nq-button-s.orange[disabled]:hover {
-      color: var(--nimiq-orange);
-      background: rgba(252, 135, 2, 0.1); /* Based on Nimiq Orange */
+    color: var(--nimiq-orange);
+    background: rgba(252, 135, 2, 0.1); /* Based on Nimiq Orange */
   }
 
   .nq-button-pill.orange {
-      background: var(--nimiq-orange);
-      background-image: var(--nimiq-orange-bg);
+    background: var(--nimiq-orange);
+    background-image: var(--nimiq-orange-bg);
   }
 
   .nq-button-pill.orange:hover,
   .nq-button-pill.orange:active,
   .nq-button-pill.orange:focus {
-      background: var(--nimiq-orange-darkened);
-      background-image: var(--nimiq-orange-bg-darkened);
+    background: var(--nimiq-orange-darkened);
+    background-image: var(--nimiq-orange-bg-darkened);
   }
 
   /* red */
   .nq-button.red {
-      background: var(--nimiq-red);
-      background-image: var(--nimiq-red-bg);
+    background: var(--nimiq-red);
+    background-image: var(--nimiq-red-bg);
   }
 
   .nq-button.red::before {
-      background: var(--nimiq-red-bg-darkened);
+    background: var(--nimiq-red-bg-darkened);
   }
 
   .nq-button.red.inverse {
-      color: var(--nimiq-red);
+    color: var(--nimiq-red);
   }
 
   .nq-button.red.inverse:hover,
   .nq-button.red.inverse:active,
   .nq-button.red.inverse:focus {
-      color: var(--nimiq-red-darkened);
+    color: var(--nimiq-red-darkened);
   }
 
   .nq-button-s.red {
-      color: var(--nimiq-red);
-      background: rgba(216, 65, 51, 0.1); /* Based on Nimiq Red */
+    color: var(--nimiq-red);
+    background: rgba(216, 65, 51, 0.1); /* Based on Nimiq Red */
   }
 
   .nq-button-s.red:hover,
   .nq-button-s.red:active,
   .nq-button-s.red:focus {
-      color: var(--nimiq-red-darkened);
-      background: rgba(216, 65, 51, 0.2); /* Based on Nimiq Red */
+    color: var(--nimiq-red-darkened);
+    background: rgba(216, 65, 51, 0.2); /* Based on Nimiq Red */
   }
 
   .nq-button-s.red[disabled]:hover {
-      color: var(--nimiq-red);
-      background: rgba(216, 65, 51, 0.1); /* Based on Nimiq Red */
+    color: var(--nimiq-red);
+    background: rgba(216, 65, 51, 0.1); /* Based on Nimiq Red */
   }
 
   .nq-button-pill.red {
-      background: var(--nimiq-red);
-      background-image: var(--nimiq-red-bg);
+    background: var(--nimiq-red);
+    background-image: var(--nimiq-red-bg);
   }
 
   .nq-button-pill.red:hover,
   .nq-button-pill.red:active,
   .nq-button-pill.red:focus {
-      background: var(--nimiq-red-darkened);
-      background-image: var(--nimiq-red-bg-darkened);
+    background: var(--nimiq-red-darkened);
+    background-image: var(--nimiq-red-bg-darkened);
   }
-
 
   /* gold */
   .nq-button.gold {
-      background: var(--nimiq-gold);
-      background-image: var(--nimiq-gold-bg);
+    background: var(--nimiq-gold);
+    background-image: var(--nimiq-gold-bg);
   }
 
   .nq-button.gold:before {
-      background: var(--nimiq-gold-bg-darkened);
+    background: var(--nimiq-gold-bg-darkened);
   }
 
   .nq-button.gold.inverse {
-      color: var(--nimiq-gold);
+    color: var(--nimiq-gold);
   }
 
   .nq-button.gold.inverse:hover,
   .nq-button.gold.inverse:active,
   .nq-button.gold.inverse:focus {
-      color: var(--nimiq-gold-darkened);
+    color: var(--nimiq-gold-darkened);
   }
 
   .nq-button-pill.gold {
-      background: var(--nimiq-gold);
-      background-image: var(--nimiq-gold-bg);
+    background: var(--nimiq-gold);
+    background-image: var(--nimiq-gold-bg);
   }
 
   .nq-button-pill.gold:hover,
   .nq-button-pill.gold:active,
   .nq-button-pill.gold:focus {
-      background: var(--nimiq-gold-darkened);
-      background-image: var(--nimiq-gold-bg-darkened);
+    background: var(--nimiq-gold-darkened);
+    background-image: var(--nimiq-gold-bg-darkened);
   }
 
   /* Special styles */
 
   .nq-button.inverse {
-      background: white;
-      color: var(--nimiq-blue);
-      transition: transform 450ms var(--nimiq-ease), box-shadow 450ms var(--nimiq-ease), color 300ms var(--nimiq-ease);
+    background: white;
+    color: var(--nimiq-blue);
+    transition: transform 450ms var(--nimiq-ease),
+      box-shadow 450ms var(--nimiq-ease), color 300ms var(--nimiq-ease);
   }
 
   .nq-button.inverse::before {
-      background: #EFF0F2; /* Indigo 7% */
+    background: #eff0f2; /* Indigo 7% */
   }
 
   .nq-button-s.inverse {
-      background: rgba(255, 255, 255, 0.2);
-      color: white;
+    background: rgba(255, 255, 255, 0.2);
+    color: white;
   }
 
   .nq-button-s.inverse:hover,
   .nq-button-s.inverse:focus,
   .nq-button-s.inverse:active {
-      background: rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.25);
   }
 
   .nq-button[disabled] {
-      background: rgba(31, 35, 72, 0.07);
-      color: rgba(31, 35, 72, 0.3);
-      box-shadow: none !important;
-      transform: none;
-      cursor: not-allowed;
+    background: rgba(31, 35, 72, 0.07);
+    color: rgba(31, 35, 72, 0.3);
+    box-shadow: none !important;
+    transform: none;
+    cursor: not-allowed;
   }
 
   .nq-button[disabled]:hover,
   .nq-button[disabled]:active {
-      transform: none;
+    transform: none;
   }
 
   .nq-button.inverse[disabled],
   .nq-button.inverse[disabled]:hover,
   .nq-button.inverse[disabled]:active {
-      background: rgba(255, 255, 255, 0.2);
-      color: rgba(255, 255, 255, 0.5);
+    background: rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.5);
   }
 
   /* Focus Ring for Tabs – can be optimized in the future with better :focus-visible support */
@@ -410,32 +413,32 @@ export default css`
   .nq-button::after,
   .nq-button-s::after,
   .nq-button-pill::after {
-      content: "";
-      position: absolute;
-      left: -5px;
-      top: -5px;
-      right: -5px;
-      bottom: -5px;
-      border: 2px solid rgba(5, 130, 202, 0.5); /* Based on Nimiq Light Blue */
-      border-radius: 500px;
-      opacity: 0;
+    content: '';
+    position: absolute;
+    left: -5px;
+    top: -5px;
+    right: -5px;
+    bottom: -5px;
+    border: 2px solid rgba(5, 130, 202, 0.5); /* Based on Nimiq Light Blue */
+    border-radius: 500px;
+    opacity: 0;
   }
 
   .nq-button.inverse::after,
   .nq-button-s.inverse::after,
   .nq-button-pill.inverse::after {
-      border-color: rgba(255,255,255,0.4);
+    border-color: rgba(255, 255, 255, 0.4);
   }
 
   .nq-button:focus,
   .nq-button-s:focus,
   .nq-button-pill:focus {
-      outline: none;
+    outline: none;
   }
 
   .nq-button:focus::after,
   .nq-button-s:focus::after,
   .nq-button-pill:focus::after {
-      opacity: 1;
+    opacity: 1;
   }
 `

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,52 +1,116 @@
-import { css } from 'lit-element';
+import { css } from 'lit-element'
 
 // https://github.com/nimiq/nimiq-style/blob/master/src/theme.css
 export default css`
   html {
     /* Nimiq color palette */
-    --nimiq-blue:       #1F2348; /* rgb(31, 35, 72) */
-    --nimiq-light-blue: #0582CA; /* rgb(5, 130, 202) */
-    --nimiq-gold:       #E9B213; /* rgb(233, 178, 19) */
-    --nimiq-green:      #21BCA5; /* rgb(33, 188, 165) */
-    --nimiq-orange:     #FC8702; /* rgb(252, 135, 2) */
-    --nimiq-red:        #D94432; /* rgb(216, 65, 51) */
-    --nimiq-purple:     #5F4B8B; /* rgb(95, 75, 139) */
-    --nimiq-pink:       #FA7268; /* rgb(250, 114, 104) */
-    --nimiq-light-green:#88B04B; /* rgb(136, 176, 75) */
-    --nimiq-brown:      #795548; /* rgb(121, 85, 72) */
-    --nimiq-gray:       #F4F4F4;
-    --nimiq-light-gray: #FAFAFA;
+    --nimiq-blue: #1f2348; /* rgb(31, 35, 72) */
+    --nimiq-light-blue: #0582ca; /* rgb(5, 130, 202) */
+    --nimiq-gold: #e9b213; /* rgb(233, 178, 19) */
+    --nimiq-green: #21bca5; /* rgb(33, 188, 165) */
+    --nimiq-orange: #fc8702; /* rgb(252, 135, 2) */
+    --nimiq-red: #d94432; /* rgb(216, 65, 51) */
+    --nimiq-purple: #5f4b8b; /* rgb(95, 75, 139) */
+    --nimiq-pink: #fa7268; /* rgb(250, 114, 104) */
+    --nimiq-light-green: #88b04b; /* rgb(136, 176, 75) */
+    --nimiq-brown: #795548; /* rgb(121, 85, 72) */
+    --nimiq-gray: #f4f4f4;
+    --nimiq-light-gray: #fafafa;
 
     /* Nimiq color palette adaptions on dark background */
-    --nimiq-light-blue-on-dark: #0CA6FE; /* rgb(12, 166, 254) */
-    --nimiq-red-on-dark:        #FF5C48; /* rgb(255, 92, 72) */
+    --nimiq-light-blue-on-dark: #0ca6fe; /* rgb(12, 166, 254) */
+    --nimiq-red-on-dark: #ff5c48; /* rgb(255, 92, 72) */
 
     /* Nimiq main colors darkened (hover states) */
-    --nimiq-blue-darkened:       #151833; /* rgb(21, 24, 51) */
-    --nimiq-light-blue-darkened: #0071C3; /* rgb(0, 113, 195) */
-    --nimiq-gold-darkened:       #E5A212; /* rgb(229, 162, 18) */
-    --nimiq-green-darkened:      #20B29E; /* rgb(32, 178, 158) */
-    --nimiq-orange-darkened:     #FC7500; /* rgb(252, 117, 0) */
-    --nimiq-red-darkened:        #D13030; /* rgb(209, 48, 48) */
+    --nimiq-blue-darkened: #151833; /* rgb(21, 24, 51) */
+    --nimiq-light-blue-darkened: #0071c3; /* rgb(0, 113, 195) */
+    --nimiq-gold-darkened: #e5a212; /* rgb(229, 162, 18) */
+    --nimiq-green-darkened: #20b29e; /* rgb(32, 178, 158) */
+    --nimiq-orange-darkened: #fc7500; /* rgb(252, 117, 0) */
+    --nimiq-red-darkened: #d13030; /* rgb(209, 48, 48) */
     /* Background gradients */
-    --nimiq-blue-bg:       radial-gradient(ellipse at bottom right, #260133, var(--nimiq-blue));
-    --nimiq-light-blue-bg: radial-gradient(ellipse at bottom right, #265DD7, var(--nimiq-light-blue));
-    --nimiq-gold-bg:       radial-gradient(ellipse at bottom right, #EC991C, var(--nimiq-gold));
-    --nimiq-green-bg:      radial-gradient(ellipse at bottom right, #41A38E, var(--nimiq-green));
-    --nimiq-orange-bg:     radial-gradient(ellipse at bottom right, #FD6216, var(--nimiq-orange));
-    --nimiq-red-bg:        radial-gradient(ellipse at bottom right, #CC3047, var(--nimiq-red));
-    --nimiq-purple-bg:     radial-gradient(ellipse at bottom right, #4D4C96, var(--nimiq-purple));
-    --nimiq-pink-bg:       radial-gradient(ellipse at bottom right, #E0516B, var(--nimiq-pink));
-    --nimiq-light-green-bg:radial-gradient(ellipse at bottom right, #70B069, var(--nimiq-light-green));
-    --nimiq-brown-bg:      radial-gradient(ellipse at bottom right, #724147, var(--nimiq-brown));
+    --nimiq-blue-bg: radial-gradient(
+      ellipse at bottom right,
+      #260133,
+      var(--nimiq-blue)
+    );
+    --nimiq-light-blue-bg: radial-gradient(
+      ellipse at bottom right,
+      #265dd7,
+      var(--nimiq-light-blue)
+    );
+    --nimiq-gold-bg: radial-gradient(
+      ellipse at bottom right,
+      #ec991c,
+      var(--nimiq-gold)
+    );
+    --nimiq-green-bg: radial-gradient(
+      ellipse at bottom right,
+      #41a38e,
+      var(--nimiq-green)
+    );
+    --nimiq-orange-bg: radial-gradient(
+      ellipse at bottom right,
+      #fd6216,
+      var(--nimiq-orange)
+    );
+    --nimiq-red-bg: radial-gradient(
+      ellipse at bottom right,
+      #cc3047,
+      var(--nimiq-red)
+    );
+    --nimiq-purple-bg: radial-gradient(
+      ellipse at bottom right,
+      #4d4c96,
+      var(--nimiq-purple)
+    );
+    --nimiq-pink-bg: radial-gradient(
+      ellipse at bottom right,
+      #e0516b,
+      var(--nimiq-pink)
+    );
+    --nimiq-light-green-bg: radial-gradient(
+      ellipse at bottom right,
+      #70b069,
+      var(--nimiq-light-green)
+    );
+    --nimiq-brown-bg: radial-gradient(
+      ellipse at bottom right,
+      #724147,
+      var(--nimiq-brown)
+    );
 
     /* Background gradients darkened (hover states) */
-    --nimiq-blue-bg-darkened:       radial-gradient(ellipse at bottom right, #180021, var(--nimiq-blue-darkened));
-    --nimiq-light-blue-bg-darkened: radial-gradient(ellipse at bottom right, #2355C4, var(--nimiq-light-blue-darkened));
-    --nimiq-gold-bg-darkened:       radial-gradient(ellipse at bottom right, #E58A1B, var(--nimiq-gold-darkened));
-    --nimiq-green-bg-darkened:      radial-gradient(ellipse at bottom right, #3D9988, var(--nimiq-green-darkened));
-    --nimiq-orange-bg-darkened:     radial-gradient(ellipse at bottom right, #EA5200, var(--nimiq-orange-darkened));
-    --nimiq-red-bg-darkened:        radial-gradient(ellipse at bottom right, #BF2D46, var(--nimiq-red-darkened));
+    --nimiq-blue-bg-darkened: radial-gradient(
+      ellipse at bottom right,
+      #180021,
+      var(--nimiq-blue-darkened)
+    );
+    --nimiq-light-blue-bg-darkened: radial-gradient(
+      ellipse at bottom right,
+      #2355c4,
+      var(--nimiq-light-blue-darkened)
+    );
+    --nimiq-gold-bg-darkened: radial-gradient(
+      ellipse at bottom right,
+      #e58a1b,
+      var(--nimiq-gold-darkened)
+    );
+    --nimiq-green-bg-darkened: radial-gradient(
+      ellipse at bottom right,
+      #3d9988,
+      var(--nimiq-green-darkened)
+    );
+    --nimiq-orange-bg-darkened: radial-gradient(
+      ellipse at bottom right,
+      #ea5200,
+      var(--nimiq-orange-darkened)
+    );
+    --nimiq-red-bg-darkened: radial-gradient(
+      ellipse at bottom right,
+      #bf2d46,
+      var(--nimiq-red-darkened)
+    );
 
     /* Special colors */
     --nimiq-highlight-bg: rgba(31, 35, 72, 0.06); /* Based on Nimiq Blue */

--- a/src/styles/typography.js
+++ b/src/styles/typography.js
@@ -1,4 +1,4 @@
-import { css } from 'lit-element';
+import { css } from 'lit-element'
 
 // https://github.com/nimiq/nimiq-style/blob/master/src/typography.css
 export default css`

--- a/src/types/IE.d.ts
+++ b/src/types/IE.d.ts
@@ -1,4 +1,4 @@
 // support IE
 declare interface Window {
-  msCrypto: Crypto;
+  msCrypto: Crypto
 }

--- a/src/types/Nimiq.d.ts
+++ b/src/types/Nimiq.d.ts
@@ -1,2 +1,2 @@
 // tslint:disable-next-line no-reference
-/// <reference path="../../node_modules/@nimiq/core-types/Nimiq.d.ts" />
+import '@nimiq/core-types/Nimiq.d.ts'

--- a/src/types/shop.ts
+++ b/src/types/shop.ts
@@ -1,5 +1,5 @@
 export type Product = {
-  name: string,
+  name: string
   price: Nimiq.Transaction
 }
 
@@ -8,19 +8,19 @@ export type OrderMeta = {
 }
 
 export type Order = {
-  price: Number,
-  products: Product[],
-  meta: OrderMeta,
-  txHash: string, // HEX
+  price: number
+  products: Product[]
+  meta: OrderMeta
+  txHash: string // HEX
   timestamp: number
 }
 
 // https://github.com/nimiq/hub/blob/master/docs/api-methods/10_checkout.md#request
 export type CheckoutOptions = {
-  appName: string,
+  appName: string
   recipient: string // user friendly address
-  value: number,
+  value: number
   shopLogoUrl?: string
-  fee?: number,
+  fee?: number
   extraData?: string
 }

--- a/src/utils/crypto.spec.ts
+++ b/src/utils/crypto.spec.ts
@@ -1,13 +1,12 @@
-import {encryptString, decryptString} from './crypto';
+// import { encryptString, decryptString } from './crypto'
 
-const message = 'secret';
+// const message = 'secret'
 
 describe('crypto', () => {
-
   // TODO(sectore): Fix test
   // it('roundtrip: encrypt/decrypt string', async () => {
   //     const encrypted = await encryptString(message);
   //     const decrypted = await decryptString(encrypted);
   //     expect(decrypted).toBe(message);
   // });
-});
+})

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,6 +1,6 @@
-const crypto: Crypto = window.crypto || window.msCrypto;
-const encoder = new TextEncoder();
-const decoder = new TextDecoder();
+const crypto: Crypto = window.crypto || window.msCrypto
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
 
 // TODO(sectore): Follow comments copied from deleted `config.js`
 //     // repo is used to namespace orders from this shop from all others
@@ -11,92 +11,92 @@ const decoder = new TextDecoder();
 
 // TODO(sectore): Another place key data than in code?
 const key: JsonWebKey = {
-  alg: "RSA-OAEP-256",
-  e: "AQAB",
+  alg: 'RSA-OAEP-256',
+  e: 'AQAB',
   ext: true,
-  key_ops: [
-      "encrypt"
-  ],
-  kty: "RSA",
-  n: "5uCgXaQKAzogc133-Y5JCBJHs-1PcuqtHX2cBnZmcoBWR0Pnvzts__SntrcEyQOZIfgt07eB2QmkGzZw3JCVSJOj8vzgCBkuLAPy0sjQQEArbrDdUrjDhP8D6DZB7KZu2RBTys-Cs9DH1XX9Qg1cgM_2-Rccd6LQMUI0o1qf1-kF9lfYXj-5g7v-KWo-WzPHXSMWsFU0UgFCM4q3nIr3ssqvOXkFHUc90Rw_Tgt-Vx-wi0RhFAYCX-0bkJBSuGB7bqRRGjL5Z_mPPZF25GqX1JiHuqLvqaVZu-AlK-L8KYw1a5gwj4opwcKUFNJXcmkI21Q0VVLTE3t9Afvzv8xcfQiYGbN5HIHwQji8TIXgdEN5yUH9-7x9Jh2lVj5Iaie_KcnZ4UQC9AwptSwhAeUNmszc0TQUGX6FxJsKnojNeYR9cUp3jS_jeP-r4BkzD7uvqt2wDP2_m5LIlC2VyKa2yx3rekqy2xPIvpaktPWl1F1U3V9zA5n8UHtamBll1LxmtWvPxQQ3dqg2yf6ogR2vZPbaKndoyL00tbZ8Op3QWmoVuHzgcdAhhiNgdwR2SgIb5taKUIebq43nBRML9DTX-SJBzUXU6218PbJeS1aStu826mwq1JKRjmKXl3JUXG_2ouY4zkebz4wfruHlZPmVtThrkLs7o3Pg5ZwhLjVjmyM"
-};
+  key_ops: ['encrypt'],
+  kty: 'RSA',
+  n:
+    '5uCgXaQKAzogc133-Y5JCBJHs-1PcuqtHX2cBnZmcoBWR0Pnvzts__SntrcEyQOZIfgt07eB2QmkGzZw3JCVSJOj8vzgCBkuLAPy0sjQQEArbrDdUrjDhP8D6DZB7KZu2RBTys-Cs9DH1XX9Qg1cgM_2-Rccd6LQMUI0o1qf1-kF9lfYXj-5g7v-KWo-WzPHXSMWsFU0UgFCM4q3nIr3ssqvOXkFHUc90Rw_Tgt-Vx-wi0RhFAYCX-0bkJBSuGB7bqRRGjL5Z_mPPZF25GqX1JiHuqLvqaVZu-AlK-L8KYw1a5gwj4opwcKUFNJXcmkI21Q0VVLTE3t9Afvzv8xcfQiYGbN5HIHwQji8TIXgdEN5yUH9-7x9Jh2lVj5Iaie_KcnZ4UQC9AwptSwhAeUNmszc0TQUGX6FxJsKnojNeYR9cUp3jS_jeP-r4BkzD7uvqt2wDP2_m5LIlC2VyKa2yx3rekqy2xPIvpaktPWl1F1U3V9zA5n8UHtamBll1LxmtWvPxQQ3dqg2yf6ogR2vZPbaKndoyL00tbZ8Op3QWmoVuHzgcdAhhiNgdwR2SgIb5taKUIebq43nBRML9DTX-SJBzUXU6218PbJeS1aStu826mwq1JKRjmKXl3JUXG_2ouY4zkebz4wfruHlZPmVtThrkLs7o3Pg5ZwhLjVjmyM',
+}
 
 const ALGORITHM = {
-  name: "RSA-OAEP",
+  name: 'RSA-OAEP',
   modulusLength: 4096,
   publicExponent: new Uint8Array([1, 0, 1]),
-  hash: "SHA-256"
-};
-
-const FORMAT = 'jwk';
-
-let importedKey = null;
-
-export const getCrypto = () => crypto;
-
-export const loadKey = async () => {
-  return importedKey || (importedKey = await importKey(key));
+  hash: 'SHA-256',
 }
 
-let pk = null;
+const FORMAT = 'jwk'
 
-const loadPk = async () => {
-  // return this.pk || (this.pk = await Crypto.importKey(localStorage.privateKey));
-  // return this.pk ? this.pk : this.pk = await Crypto.importKey(localStorage.privateKey);
-  if (!pk) {
-      pk = await importKey(localStorage.privateKey);
-  }
-  return pk;
-}
-
-export const hash = async(s: string) => {
-  const data = encoder.encode(s);
-  return await crypto.subtle.digest(ALGORITHM.hash, data);
-}
+export const getCrypto = (): Crypto => crypto
 
 export const importKey = async (key: JsonWebKey): Promise<CryptoKey> => {
   // return await crypto.importKey(FORMAT, key, ALGORITHM, false, ['encrypt', 'decrypt']);
-  return await crypto.subtle.importKey(FORMAT, key, ALGORITHM, false, key.key_ops);
-}
-
-export const exportKey = async (key: CryptoKey) => {
-  const exported = await crypto.subtle.exportKey(FORMAT, key);
-  return JSON.stringify(exported, null, " ");
-}
-
-export const generateKey = async (): Promise<CryptoKey|CryptoKeyPair> =>
-  crypto.subtle.generateKey(ALGORITHM, 
-    true, 
-    ['encrypt', 'decrypt']
+  return await crypto.subtle.importKey(
+    FORMAT,
+    key,
+    ALGORITHM,
+    false,
+    key.key_ops,
   )
+}
 
-export const encryptObject = async (o: Object): Promise<string> => {
-    const data: string = JSON.stringify(o);
-    return await encryptString(data);
+let importedKey = null
+
+export const loadKey = async (): Promise<any> => {
+  return importedKey || (importedKey = await importKey(key))
+}
+
+export const hash = async (s: string): Promise<ArrayBuffer> => {
+  const data = encoder.encode(s)
+  return await crypto.subtle.digest(ALGORITHM.hash, data)
+}
+
+let pk = null
+
+const loadPk = async (): Promise<CryptoKey> => {
+  return pk || (pk = await importKey(localStorage.privateKey))
+}
+
+export const exportKey = async (key: CryptoKey): Promise<string> => {
+  const exported = await crypto.subtle.exportKey(FORMAT, key)
+  return JSON.stringify(exported, null, ' ')
+}
+
+export const generateKey = async (): Promise<CryptoKey | CryptoKeyPair> =>
+  crypto.subtle.generateKey(ALGORITHM, true, ['encrypt', 'decrypt'])
+
+export const encryptRaw = async (data: Uint8Array): Promise<string> => {
+  const key = await loadKey()
+  const encrypted = await crypto.subtle.encrypt(ALGORITHM, key, data)
+  return decoder.decode(encrypted)
 }
 
 export const encryptString = async (s: string): Promise<string> => {
-    const data: Uint8Array = encoder.encode(s);
-    return await encryptRaw(data);
+  const data: Uint8Array = encoder.encode(s)
+  return await encryptRaw(data)
 }
 
-export const encryptRaw = async (data: Uint8Array): Promise<string> => {
-  const key = await loadKey();
-  const encrypted = await crypto.subtle.encrypt(ALGORITHM, key, data);
-  return decoder.decode(encrypted);
+/*eslint @typescript-eslint/no-explicit-any: "off" */
+export const encryptObject = async (
+  o: Record<string, any>,
+): Promise<string> => {
+  const data: string = JSON.stringify(o)
+  return await encryptString(data)
 }
 
-export const decryptRaw = async(data: string): Promise<ArrayBuffer> => {
-    const encoded = encoder.encode(data);
-    return await crypto.subtle.decrypt(ALGORITHM, await loadPk(), encoded);
+export const decryptRaw = async (data: string): Promise<ArrayBuffer> => {
+  const encoded = encoder.encode(data)
+  return await crypto.subtle.decrypt(ALGORITHM, await loadPk(), encoded)
 }
 
-export const decryptString = async (data: string) => {
-    const decrypted = await decryptRaw(data);
-    return decoder.decode(decrypted);
+export const decryptString = async (data: string): Promise<string> => {
+  const decrypted = await decryptRaw(data)
+  return decoder.decode(decrypted)
 }
 
 export const decryptObject = async <T>(data: string): Promise<T> => {
-    const decrypted = await decryptString(data);
-    return JSON.parse(decrypted) as T;
+  const decrypted = await decryptString(data)
+  return JSON.parse(decrypted) as T
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,22 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
+  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
+  integrity sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
 "@nimiq/core-types@^1.4.2":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@nimiq/core-types/-/core-types-1.4.2.tgz#16e7bbc9a1b5a9dd5f7d0d735ef07f096799946c"
@@ -18,6 +34,11 @@
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@nimiq/rpc/-/rpc-0.3.0.tgz#654c05acccc193b7d79fb09b2faf2114945ff872"
   integrity sha512-je7fv+wP4nLEgTcZwu3FaGre22qkZ9AYGbStglVaJAxOH+3CvDnnOIa9IjGFaCEhtRQKRaQEvFqa5vN4IVnH+Q==
+
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
 "@types/events@*":
   version "3.0.0"
@@ -38,6 +59,11 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.4.2.tgz#49f672de24043b3c1fb919901fd3cd36f027bc93"
   integrity sha512-SaSSGOzwUnBEn64c+HTyVTJhRf8F1CXZLnxYx2ww3UrgGBmEEw38RSux2l3fYiT9brVLP67DU5omWA6V9OHI5Q==
 
+"@types/json-schema@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
+  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -47,6 +73,47 @@
   version "12.7.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.8.tgz#cb1bf6800238898bc2ff6ffa5702c3cadd350708"
   integrity sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A==
+
+"@typescript-eslint/eslint-plugin@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.5.0.tgz#101d96743ce3365b3223df73d641078c9b775903"
+  integrity sha512-ddrJZxp5ns1Lh5ofZQYk3P8RyvKfyz/VcRR4ZiJLHO/ljnQAO8YvTfj268+WJOOadn99mvDiqJA65+HAKoeSPA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.5.0"
+    eslint-utils "^1.4.2"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^2.0.1"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.5.0.tgz#383a97ded9a7940e5053449f6d73995e782b8fb1"
+  integrity sha512-UgcQGE0GKJVChyRuN1CWqDW8Pnu7+mVst0aWrhiyuUD1J9c+h8woBdT4XddCvhcXDodTDVIfE3DzGHVjp7tUeQ==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.5.0"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/parser@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.5.0.tgz#858030ddd808fbbe88e03f42e5971efaccb8218a"
+  integrity sha512-9UBMiAwIDWSl79UyogaBdj3hidzv6exjKUx60OuZuFnJf56tq/UMpdPcX09YmGqE8f4AnAueYtBxV8IcAT3jdQ==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.5.0"
+    "@typescript-eslint/typescript-estree" "2.5.0"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/typescript-estree@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.5.0.tgz#40ada624d6217ef092a3a79ed30d947ad4f212ce"
+  integrity sha512-AXURyF8NcA3IsnbjNX1v9qbwa0dDoY9YPcKYR2utvMHoUcu3636zrz0gRWtVAyxbPCkhyKuGg6WZIyi2Fc79CA==
+  dependencies:
+    debug "^4.1.1"
+    glob "^7.1.4"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -217,10 +284,20 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+acorn-jsx@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
+  integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
+
 acorn@^6.2.1:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
   integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+
+acorn@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
 after@0.8.2:
   version "0.8.2"
@@ -237,7 +314,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.2:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
   integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
@@ -251,6 +328,11 @@ ansi-colors@^3.0.0:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
+
+ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-html@0.0.7:
   version "0.0.7"
@@ -307,6 +389,13 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -376,6 +465,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 async-each@^1.0.1:
   version "1.0.3"
@@ -715,6 +809,11 @@ callsite@1.0.0:
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
   integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
 
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
 camel-case@3.0.x:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
@@ -728,7 +827,7 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-chalk@2.4.2, chalk@^2.3.0, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -736,6 +835,11 @@ chalk@2.4.2, chalk@^2.3.0, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 chokidar@^2.0.2, chokidar@^2.1.8:
   version "2.1.8"
@@ -807,6 +911,18 @@ clean-css@4.2.x:
   integrity sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==
   dependencies:
     source-map "~0.6.0"
+
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -1062,7 +1178,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@6.0.5, cross-spawn@^6.0.0:
+cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -1162,7 +1278,7 @@ debug@^3.0.0, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -1202,6 +1318,11 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
 default-gateway@^4.2.0:
   version "4.2.0"
@@ -1324,6 +1445,13 @@ dns-txt@^2.0.2:
   integrity sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
   dependencies:
     buffer-indexof "^1.0.0"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -1563,6 +1691,20 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+eslint-config-prettier@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.4.0.tgz#0a04f147e31d33c6c161b2dd0971418ac52d0477"
+  integrity sha512-YrKucoFdc7SEko5Sxe4r6ixqXPDP1tunGw91POeZTTRKItf/AMFYt/YLEQtZMkR2LVpAVhcAcZgcWpm1oGPW7w==
+  dependencies:
+    get-stdin "^6.0.0"
+
+eslint-plugin-prettier@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz#507b8562410d02a03f0ddc949c616f877852f2ba"
+  integrity sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -1571,6 +1713,90 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^1.4.2:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+
+eslint@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.5.1.tgz#828e4c469697d43bb586144be152198b91e96ed6"
+  integrity sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.10.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.2"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.1"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.4.1"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.14"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^6.1.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.2.tgz#6c272650932b4f91c3714e5e7b5f5e2ecf47262d"
+  integrity sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==
+  dependencies:
+    acorn "^7.1.0"
+    acorn-jsx "^5.1.0"
+    eslint-visitor-keys "^1.1.0"
+
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+esquery@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
+  integrity sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
+  dependencies:
+    estraverse "^4.0.0"
+
 esrecurse@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
@@ -1578,10 +1804,15 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 etag@~1.8.1:
   version "1.8.1"
@@ -1702,6 +1933,15 @@ extend@^3.0.0:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+external-editor@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -1721,10 +1961,20 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 faye-websocket@^0.10.0:
   version "0.10.0"
@@ -1744,6 +1994,20 @@ figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
   integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -1800,6 +2064,15 @@ findup-sync@3.0.0:
     is-glob "^4.0.0"
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
+
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
 
 flatted@^2.0.0:
   version "2.0.1"
@@ -1900,6 +2173,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -1924,6 +2202,11 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
 get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -1944,7 +2227,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
   integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
@@ -1998,6 +2281,11 @@ global-prefix@^3.0.0:
     ini "^1.3.5"
     kind-of "^6.0.2"
     which "^1.3.1"
+
+globals@^11.7.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globby@^6.1.0:
   version "6.1.0"
@@ -2241,7 +2529,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-iconv-lite@0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -2271,6 +2559,19 @@ ignore-walk@^3.0.1:
   integrity sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==
   dependencies:
     minimatch "^3.0.4"
+
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+import-fresh@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
+  integrity sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-local@2.0.0, import-local@^2.0.0:
   version "2.0.0"
@@ -2327,6 +2628,25 @@ ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+inquirer@^6.4.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
+  integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^2.0.0"
+    lodash "^4.17.12"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -2532,6 +2852,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -2600,6 +2925,19 @@ jasmine-core@^3.3, jasmine-core@^3.5.0:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.5.0.tgz#132c23e645af96d85c8bca13c8758b18429fc1e4"
   integrity sha512-nCeAiw37MIMA9w9IXso7bRaLl+c/ef3wnxsoSAlYrzS+Ot0zTG6nU8G/cIfGkqpkjX2wNaIW9RFG0TwIFnG6bA==
 
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -2609,6 +2947,11 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json3@^3.3.2:
   version "3.3.3"
@@ -2729,6 +3072,14 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 lit-element@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.2.1.tgz#79c94d8cfdc2d73b245656e37991bd1e4811d96f"
@@ -2773,7 +3124,12 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.3:
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.3:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -2949,6 +3305,11 @@ mime@^2.3.1, mime@^2.4.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
 mimic-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -3072,6 +3433,11 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+
 nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -3093,6 +3459,11 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
 needle@^2.2.1:
   version "2.4.0"
@@ -3317,6 +3688,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+  dependencies:
+    mimic-fn "^1.0.0"
+
 opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -3331,6 +3709,18 @@ optimist@^0.6.1:
   dependencies:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
+
+optionator@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
 
 original@^1.0.0:
   version "1.0.2"
@@ -3437,6 +3827,13 @@ param-case@2.1.x:
   integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
   dependencies:
     no-case "^2.2.0"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-asn1@^5.0.0:
   version "5.1.5"
@@ -3629,6 +4026,23 @@ postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.5, postcss@^7.0.
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 pretty-error@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
@@ -3646,6 +4060,11 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -3840,6 +4259,11 @@ regexp.prototype.flags@^1.2.0:
   dependencies:
     define-properties "^1.1.2"
 
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
 relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
@@ -3911,10 +4335,23 @@ resolve-from@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
 
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -3931,6 +4368,13 @@ rfdc@^1.1.4:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.1.4.tgz#ba72cc1367a0ccd9cf81a870b3b58bd3ad07f8c2"
   integrity sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==
 
+rimraf@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
@@ -3946,12 +4390,26 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
+  dependencies:
+    is-promise "^2.1.0"
+
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rxjs@^6.4.0:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
+  integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -4014,7 +4472,7 @@ semver@^5.3.0, semver@^5.5.0, semver@^5.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -4123,10 +4581,19 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-signal-exit@^3.0.0:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
+    is-fullwidth-code-point "^2.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -4298,6 +4765,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
 ssri@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
@@ -4370,7 +4842,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -4443,6 +4915,11 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
+strip-json-comments@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
+  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -4469,6 +4946,16 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+table@^5.2.3:
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
+  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+  dependencies:
+    ajv "^6.10.2"
+    lodash "^4.17.14"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
@@ -4512,6 +4999,11 @@ terser@^4.1.2:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
 through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -4519,6 +5011,11 @@ through2@^2.0.0:
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+through@^2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 thunky@^1.0.2:
   version "1.0.3"
@@ -4532,7 +5029,7 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tmp@0.0.33, tmp@0.0.x:
+tmp@0.0.33, tmp@0.0.x, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
@@ -4602,15 +5099,29 @@ ts-loader@^6.2.0:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
-tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+  dependencies:
+    prelude-ls "~1.1.2"
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
@@ -4787,6 +5298,11 @@ v8-compile-cache@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
   integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
+
+v8-compile-cache@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
+  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
 vary@~1.1.2:
   version "1.1.2"
@@ -4969,6 +5485,11 @@ wordwrap@~0.0.2:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
   integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
 
+wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
 worker-farm@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
@@ -4997,6 +5518,13 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@^6.2.1:
   version "6.2.1"


### PR DESCRIPTION
Use `Prettier` for code formatting and `es-lint` for linting TypeScript. Run `yarn fix-ts` to run and to fix `es-lint` issues. 

Note: We still have some `es-lint` issues in `storage.ts` and `crypto.ts`. Both files are still `WIP` and will be fixed later. Later we should use [`husky`](https://github.com/typicode/husky) to add `git precommit` hooks.

